### PR TITLE
Restrict npm publishing to source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "main": "./lib/reporter.js",
   "scripts": {
     "test": "make ci"
-  }
+  },
+  "files": [
+    "lib"
+  ]
 }


### PR DESCRIPTION
This ensures that things like tests are not included in the npm package and reduces the overall size by approximately 40%.